### PR TITLE
mention useContentScriptContext

### DIFF
--- a/sidebar-boilerplate/pane.js
+++ b/sidebar-boilerplate/pane.js
@@ -1,7 +1,11 @@
+var options = {
+  useContentScriptContext: true // eval in the content script context
+};
+
 chrome.devtools.panels.elements.onSelectionChanged.addListener(function() {
     chrome.devtools.inspectedWindow.eval("$0", function (res) {
-       
-    });
+
+    }, options);
 });
 chrome.extension.onMessage.addListener(function (msg, _, sendResponse) {
     console.log(msg, _, sendResponse);


### PR DESCRIPTION
Useful for exchanging data, like the currently selected element, with the content script. This option is very useful, but only briefly mentioned in the docs.
